### PR TITLE
Source code editor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,7 +255,7 @@ lazy val clusterShared = (project in file("cluster/shared"))
 lazy val clusterMaster = (project in file("cluster/master"))
   .enablePlugins(
     AutomateHeaderPlugin,
-    SbtSass,
+    SbtSassify,
     SbtTwirl,
     JavaServerAppPackaging,
     DockerPlugin
@@ -297,6 +297,7 @@ lazy val clusterWorker = (project in file("cluster/worker"))
 // Misc Utilities ===========================================
 
 lazy val util = (crossProject in file("util"))
+  .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .jsSettings(Dependencies.utilJS)
   .settings(moduleName := "quckoo-util")

--- a/cluster/master/src/main/assets/css/_imports.scss
+++ b/cluster/master/src/main/assets/css/_imports.scss
@@ -1,4 +1,6 @@
 @import "lib/bootstrap-sass/stylesheets/bootstrap.scss";
 @import "lib/font-awesome/scss/font-awesome.scss";
 @import "lib/animatewithsass/animate.scss";
+
 @import "lib/codemirror/lib/codemirror";
+@import "lib/codemirror/theme/solarized";

--- a/cluster/master/src/main/assets/css/_imports.scss
+++ b/cluster/master/src/main/assets/css/_imports.scss
@@ -1,3 +1,4 @@
 @import "lib/bootstrap-sass/stylesheets/bootstrap.scss";
 @import "lib/font-awesome/scss/font-awesome.scss";
 @import "lib/animatewithsass/animate.scss";
+@import "lib/codemirror/lib/codemirror";

--- a/cluster/master/src/main/twirl/io/quckoo/console/main.scala.html
+++ b/cluster/master/src/main/twirl/io/quckoo/console/main.scala.html
@@ -7,7 +7,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>@title</title>
-        <link rel="stylesheet" type="text/css" href="/assets/css/application.min.css">
+        <link rel="stylesheet" type="text/css" href="/assets/css/application.css">
     </head>
     <body>
         @content

--- a/console/src/main/scala/io/quckoo/console/SiteMap.scala
+++ b/console/src/main/scala/io/quckoo/console/SiteMap.scala
@@ -52,8 +52,8 @@ object SiteMap {
       import dsl._
 
       (emptyRule
-        | staticRoute(root, RootRoute) ~> redirectToPage(DashboardRoute)(Redirect.Push)
-        | staticRoute("#login", LoginRoute) ~> render(loginPage(proxy)(None)))
+        | staticRoute(root, Root) ~> redirectToPage(Dashboard)(Redirect.Push)
+        | staticRoute("#login", Login) ~> render(loginPage(proxy)(None)))
     }
 
   private[this] def privatePages(proxy: ModelProxy[ConsoleScope]) =
@@ -69,9 +69,9 @@ object SiteMap {
         Some(render(loginPage(proxy)(Some(referral))))
 
       (emptyRule
-        | staticRoute("#home", DashboardRoute) ~> render(dashboardPage(proxy))
-        | staticRoute("#registry", RegistryRoute) ~> render(registryPage(proxy))
-        | staticRoute("#scheduler", SchedulerRoute) ~> render(schedulerPage(proxy)))
+        | staticRoute("#home", Dashboard) ~> render(dashboardPage(proxy))
+        | staticRoute("#registry", Registry) ~> render(registryPage(proxy))
+        | staticRoute("#scheduler", Scheduler) ~> render(schedulerPage(proxy)))
         .addCondition(isLoggedIn)(redirectToLogin)
     }
 
@@ -82,15 +82,15 @@ object SiteMap {
       (emptyRule
         | publicPages(proxy)
         | privatePages(proxy))
-        .notFound(redirectToPage(RootRoute)(Redirect.Replace))
+        .notFound(redirectToPage(Root)(Redirect.Replace))
         .renderWith(layout(proxy))
-        .verify(ConsoleRoute.all.head, ConsoleRoute.all.tail: _*)
+        .verify(ConsoleRoute.values.head, ConsoleRoute.values.tail: _*)
     }
 
   val mainMenu = List(
-    NavigationItem(Icons.dashboard, "Dashboard", DashboardRoute),
-    NavigationItem(Icons.book, "Registry", RegistryRoute),
-    NavigationItem(Icons.clockO, "Scheduler", SchedulerRoute)
+    NavigationItem(Icons.dashboard, "Dashboard", Dashboard),
+    NavigationItem(Icons.book, "Registry", Registry),
+    NavigationItem(Icons.clockO, "Scheduler", Scheduler)
   )
 
   def layout(proxy: ModelProxy[ConsoleScope])(ctrl: RouterCtl[ConsoleRoute],

--- a/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
+++ b/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
@@ -23,6 +23,7 @@ import japgolly.scalajs.react.extra._
 import japgolly.scalajs.react.vdom.prefix_<^._
 
 import org.scalajs.dom.html
+import scala.scalajs.js
 
 /**
   * Created by alonsodomin on 02/03/2017.
@@ -56,7 +57,7 @@ object CodeEditor {
     }
 
     def render(props: Props, state: State) = {
-      <.textarea(props.attrs)
+      <.textarea(^.`class` := "form-control", props.attrs)
     }
 
   }
@@ -66,7 +67,11 @@ object CodeEditor {
     .renderBackend[Backend]
     .componentDidMount($ => Callback {
       val textArea = $.getDOMNode().asInstanceOf[html.TextArea]
-      val codeMirror = CodeMirror.fromTextArea(textArea)
+      val codeMirror = CodeMirror.fromTextArea(textArea, js.Dynamic.literal(
+        "mode" -> "shell",
+        "linenumbers" -> true,
+        "theme" -> "solarized light"
+      ))
       $.backend.mounted($.state, codeMirror)
     })
     .build

--- a/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
+++ b/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quckoo.console.components
+
+import io.quckoo.console.libs.CodeMirror
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.extra._
+import japgolly.scalajs.react.vdom.prefix_<^._
+
+import org.scalajs.dom.html
+
+/**
+  * Created by alonsodomin on 02/03/2017.
+  */
+object CodeEditor {
+
+  type OnUpdate = Option[String] => Callback
+
+  case class Props(text: Option[String], onUpdate: OnUpdate, attrs: Seq[TagMod])
+  case class State(value: Option[String])
+
+  implicit val propsReuse: Reusability[Props] = Reusability.caseClassExcept('onUpdate, 'attrs)
+  implicit val stateReuse: Reusability[State] = Reusability.caseClass[State]
+
+  class Backend($: BackendScope[Props, State]) {
+
+    private[this] def propagateUpdate: Callback =
+      $.state.flatMap(st => $.props.flatMap(_.onUpdate(st.value)))
+
+    def mounted(state: State, codeMirror: CodeMirror) = {
+      codeMirror.setValue(state.value.getOrElse(""))
+    }
+
+    def onUpdate(evt: ReactEventI): Callback = {
+      val newValue = {
+        if (evt.target.value.isEmpty) None
+        else Some(evt.target.value)
+      }
+
+      $.modState(_.copy(value = newValue), propagateUpdate)
+    }
+
+    def render(props: Props, state: State) = {
+      <.textarea(props.attrs)
+    }
+
+  }
+
+  val component = ReactComponentB[Props]("CodeEditor")
+    .initialState_P(props => State(props.text))
+    .renderBackend[Backend]
+    .componentDidMount($ => Callback {
+      val textArea = $.getDOMNode().asInstanceOf[html.TextArea]
+      val codeMirror = CodeMirror.fromTextArea(textArea)
+      $.backend.mounted($.state, codeMirror)
+    })
+    .build
+
+  def apply(value: Option[String], onUpdate: OnUpdate, attrs: TagMod*) =
+    component(Props(value, onUpdate, attrs))
+
+}

--- a/console/src/main/scala/io/quckoo/console/components/LookAndFeel.scala
+++ b/console/src/main/scala/io/quckoo/console/components/LookAndFeel.scala
@@ -70,6 +70,8 @@ class LookAndFeel(implicit r: Register) extends StyleSheet.Inline()(r) {
     val header  = wrap("modal-header")
     val body    = wrap("modal-body")
     val footer  = wrap("modal-footer")
+    val large   = wrap("modal-lg")
+    val small   = wrap("modal-sm")
   }
 
   val formGroup   = wrap("form-group")

--- a/console/src/main/scala/io/quckoo/console/components/Modal.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Modal.scala
@@ -16,8 +16,11 @@
 
 package io.quckoo.console.components
 
+import io.quckoo.console.libs._
+
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.prefix_<^._
+
 import org.scalajs.jquery._
 
 import scala.scalajs.js

--- a/console/src/main/scala/io/quckoo/console/components/Notification.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Notification.scala
@@ -18,6 +18,7 @@ package io.quckoo.console.components
 
 import io.quckoo.Fault
 import io.quckoo.console.components.Notification._
+import io.quckoo.console.libs._
 
 import japgolly.scalajs.react.ReactNode
 import japgolly.scalajs.react.vdom.prefix_<^._

--- a/console/src/main/scala/io/quckoo/console/components/package.scala
+++ b/console/src/main/scala/io/quckoo/console/components/package.scala
@@ -25,8 +25,6 @@ import io.quckoo._
 import japgolly.scalajs.react.ReactNode
 import japgolly.scalajs.react.extra.Reusability
 
-import org.scalajs.jquery.{JQuery, JQueryStatic}
-
 import org.threeten.bp.{LocalDate, LocalDateTime, LocalTime, ZonedDateTime}
 
 import scalacss.Defaults._
@@ -82,13 +80,5 @@ package object components {
 
   implicit def toReactNode(notification: Notification): ReactNode =
     notification.inline
-
-  // JQuery plugins
-
-  implicit def toBootstrapJQuery(jq: JQuery): BootstrapJQuery =
-    jq.asInstanceOf[BootstrapJQuery]
-
-  implicit def jq2Notify(jq: JQueryStatic): BootstrapNotify =
-    jq.asInstanceOf[BootstrapNotify]
 
 }

--- a/console/src/main/scala/io/quckoo/console/core/LoginProcessor.scala
+++ b/console/src/main/scala/io/quckoo/console/core/LoginProcessor.scala
@@ -52,17 +52,17 @@ class LoginProcessor(routerCtl: RouterCtl[ConsoleRoute])
         EffectOnly(Growl(authFailedNotification))
 
       case LoggedIn(passport, referral) =>
-        val destination = referral.getOrElse(DashboardRoute)
+        val destination = referral.getOrElse(Dashboard)
         val newModel = currentModel.copy(
           passport = Some(passport),
           lastLogin = Some(LocalDateTime.now(clock))
         )
-        logger.info("Successfully logged in! Redirecting to {}", destination)
+        logger.info("Successfully logged in! Redirecting to {}", destination.entryName)
         ModelUpdateEffect(newModel, NavigateTo(destination))
 
       case LoggedOut =>
         logger.info("Successfully logged out.")
-        val action = Effect.action(NavigateTo(DashboardRoute))
+        val action = Effect.action(NavigateTo(Dashboard))
         ModelUpdateEffect(currentModel.copy(passport = None), action)
 
       case NavigateTo(route) =>

--- a/console/src/main/scala/io/quckoo/console/layout/Navigation.scala
+++ b/console/src/main/scala/io/quckoo/console/layout/Navigation.scala
@@ -33,7 +33,7 @@ import japgolly.scalajs.react.vdom.prefix_<^._
  * Created by alonsodomin on 16/10/2015.
  */
 object Navigation {
-  import ConsoleRoute.DashboardRoute
+  import ConsoleRoute.Dashboard
 
   sealed trait NavigationMenu
   case class NavigationList(icon: Icon, name: String, items: List[NavigationMenu]) extends NavigationMenu
@@ -90,7 +90,7 @@ object Navigation {
         <.div(^.`class` := "container-fluid",
           <.div(^.`class` := "navbar-header",
             <.a(^.`class` := "navbar-brand",
-              ^.href := props.routerCtl.urlFor(DashboardRoute).value,
+              ^.href := props.routerCtl.urlFor(Dashboard).value,
               ^.onClick ==> navigationItemClicked(props.initial),
               Icons.home, "Quckoo"
             )

--- a/console/src/main/scala/io/quckoo/console/libs/BootstrapJQuery.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/BootstrapJQuery.scala
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package io.quckoo.md5
+package io.quckoo.console.libs
+
+import org.scalajs.jquery.JQuery
 
 import scala.scalajs.js
 
+/**
+  * Created by alonsodomin on 20/02/2016.
+  */
 @js.native
-object SparkMD5 extends js.Object {
-
-  @js.native
-  class ArrayBuffer() extends js.Object {
-    def append(chunk: js.typedarray.ArrayBuffer): Unit = js.native
-    def end(raw: Boolean = false): String = js.native
-  }
-  
+trait BootstrapJQuery extends JQuery {
+  def modal(action: String): BootstrapJQuery  = js.native
+  def modal(options: js.Any): BootstrapJQuery = js.native
 }

--- a/console/src/main/scala/io/quckoo/console/libs/BootstrapNotify.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/BootstrapNotify.scala
@@ -14,17 +14,27 @@
  * limitations under the License.
  */
 
-package io.quckoo.md5
+package io.quckoo.console.libs
+
+import org.scalajs.jquery.JQueryStatic
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
 
+/**
+  * Created by alonsodomin on 28/03/2016.
+  */
 @js.native
-object SparkMD5 extends js.Object {
+trait BootstrapNotify extends JQueryStatic {
 
-  @js.native
-  class ArrayBuffer() extends js.Object {
-    def append(chunk: js.typedarray.ArrayBuffer): Unit = js.native
-    def end(raw: Boolean = false): String = js.native
-  }
-  
+  @JSName("notify")
+  def showNotification(content: String, options: js.Any = js.Dynamic.literal()): this.type =
+    js.native
+
+  @JSName("notifyDefaults")
+  def notificationDefaults(options: js.Any): BootstrapNotify = js.native
+
+  @JSName("notifyClose")
+  def closeNotification(id: String = "all"): BootstrapNotify = js.native
+
 }

--- a/console/src/main/scala/io/quckoo/console/libs/CodeMirror.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/CodeMirror.scala
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-package io.quckoo.console.components
+package io.quckoo.console.libs
 
-import org.scalajs.jquery.JQueryStatic
+import org.scalajs.dom.html.TextArea
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSImport
 
 /**
-  * Created by alonsodomin on 28/03/2016.
+  * Created by alonsodomin on 02/03/2017.
   */
 @js.native
-trait BootstrapNotify extends JQueryStatic {
+object CodeMirror extends js.Object {
 
-  @JSName("notify")
-  def showNotification(content: String, options: js.Any = js.Dynamic.literal()): this.type =
-    js.native
+  def fromTextArea(textArea: TextArea, options: js.Any = js.Dynamic.literal()): CodeMirror = js.native
 
-  @JSName("notifyDefaults")
-  def notificationDefaults(options: js.Any): BootstrapNotify = js.native
+}
 
-  @JSName("notifyClose")
-  def closeNotification(id: String = "all"): BootstrapNotify = js.native
+@js.native
+trait CodeMirror extends js.Object {
+
+  def getValue(separator: js.UndefOr[String] = null): String = js.native
+  def setValue(content: String): this.type = js.native
 
 }

--- a/console/src/main/scala/io/quckoo/console/libs/codemirror/ChangeEvent.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/codemirror/ChangeEvent.scala
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-package io.quckoo.console
+package io.quckoo.console.libs.codemirror
 
-import enumeratum._
+import scala.scalajs.js
 
 /**
-  * Created by alonsodomin on 26/03/2016.
+  * Created by alonsodomin on 03/03/2017.
   */
-sealed trait ConsoleRoute extends EnumEntry with EnumEntry.Lowercase
-object ConsoleRoute extends Enum[ConsoleRoute] {
-  case object Root      extends ConsoleRoute
-  case object Dashboard extends ConsoleRoute
-  case object Login     extends ConsoleRoute
-  case object Registry  extends ConsoleRoute
-  case object Scheduler extends ConsoleRoute
+@js.native
+trait Position extends js.Object {
+  def ch: Int = js.native
+  def line: Int = js.native
+}
 
-  val values = findValues
+@js.native
+trait ChangeEvent extends js.Object {
+  def from: Position = js.native
+  def to: Position = js.native
+  def text: js.Array[String] = js.native
+  def removed: String = js.native
+  def origin: String = js.native
 }

--- a/console/src/main/scala/io/quckoo/console/libs/codemirror/CodeMirror.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/codemirror/CodeMirror.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package io.quckoo.console.libs
+package io.quckoo.console.libs.codemirror
 
 import org.scalajs.dom.html.TextArea
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
 
 /**
   * Created by alonsodomin on 02/03/2017.
@@ -36,5 +36,9 @@ trait CodeMirror extends js.Object {
 
   def getValue(separator: js.UndefOr[String] = null): String = js.native
   def setValue(content: String): this.type = js.native
+
+  def setSize(width: Width, height: Height): this.type  = js.native
+
+  def on(`type`: String, handler: js.Function2[CodeMirror, js.Any, _]): this.type = js.native
 
 }

--- a/console/src/main/scala/io/quckoo/console/libs/codemirror/CodeMirrorReact.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/codemirror/CodeMirrorReact.scala
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package io.quckoo.console
+package io.quckoo.console.libs.codemirror
 
-import enumeratum._
+import japgolly.scalajs.react.extra.Reusability
 
 /**
-  * Created by alonsodomin on 26/03/2016.
+  * Created by alonsodomin on 03/03/2017.
   */
-sealed trait ConsoleRoute extends EnumEntry with EnumEntry.Lowercase
-object ConsoleRoute extends Enum[ConsoleRoute] {
-  case object Root      extends ConsoleRoute
-  case object Dashboard extends ConsoleRoute
-  case object Login     extends ConsoleRoute
-  case object Registry  extends ConsoleRoute
-  case object Scheduler extends ConsoleRoute
-
-  val values = findValues
+object CodeMirrorReact {
+  implicit val lengthReuse: Reusability[Length] = Reusability.byRef
 }

--- a/console/src/main/scala/io/quckoo/console/libs/codemirror/package.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/codemirror/package.scala
@@ -14,20 +14,17 @@
  * limitations under the License.
  */
 
-package io.quckoo.console
+package io.quckoo.console.libs
 
-import enumeratum._
+import scala.scalajs.js.|
 
 /**
-  * Created by alonsodomin on 26/03/2016.
+  * Created by alonsodomin on 03/03/2017.
   */
-sealed trait ConsoleRoute extends EnumEntry with EnumEntry.Lowercase
-object ConsoleRoute extends Enum[ConsoleRoute] {
-  case object Root      extends ConsoleRoute
-  case object Dashboard extends ConsoleRoute
-  case object Login     extends ConsoleRoute
-  case object Registry  extends ConsoleRoute
-  case object Scheduler extends ConsoleRoute
+package object codemirror {
 
-  val values = findValues
+  type Length = Int | String
+  type Width = Length
+  type Height = Length
+
 }

--- a/console/src/main/scala/io/quckoo/console/libs/package.scala
+++ b/console/src/main/scala/io/quckoo/console/libs/package.scala
@@ -14,17 +14,23 @@
  * limitations under the License.
  */
 
-package io.quckoo.console.components
+package io.quckoo.console
 
-import org.scalajs.jquery.JQuery
+import org.scalajs.jquery.{JQuery, JQueryStatic}
 
-import scala.scalajs.js
+import scala.language.implicitConversions
 
 /**
-  * Created by alonsodomin on 20/02/2016.
+  * Created by alonsodomin on 02/03/2017.
   */
-@js.native
-trait BootstrapJQuery extends JQuery {
-  def modal(action: String): BootstrapJQuery  = js.native
-  def modal(options: js.Any): BootstrapJQuery = js.native
+package object libs {
+
+  // JQuery plugins
+
+  implicit def toBootstrapJQuery(jq: JQuery): BootstrapJQuery =
+    jq.asInstanceOf[BootstrapJQuery]
+
+  implicit def jq2Notify(jq: JQueryStatic): BootstrapNotify =
+    jq.asInstanceOf[BootstrapNotify]
+
 }

--- a/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
@@ -28,6 +28,13 @@ import scalacss.ScalaCssReact._
 object ShellScriptPackageInput {
   @inline private def lnf = lookAndFeel
 
+  final val DefaultScript =
+    """
+      |#!/bin/bash
+      |
+      |echo "Hello World"
+    """.stripMargin
+
   type OnUpdate = Option[ShellScriptPackage] => Callback
 
   case class Props(value: Option[ShellScriptPackage], onUpdate: OnUpdate)
@@ -48,7 +55,8 @@ object ShellScriptPackageInput {
       <.div(lnf.formGroup,
         <.label(^.`class` := "col-sm-2 control-label", ^.`for` := "script_content", "Script"),
         <.div(^.`class` := "col-sm-10",
-          TextArea(state.content, onContentUpdate, ^.id := "script_content")
+          //TextArea(state.content, onContentUpdate, ^.id := "script_content")
+          CodeEditor(state.content, onContentUpdate, ^.id := "script_content")
         )
       )
     }
@@ -56,7 +64,7 @@ object ShellScriptPackageInput {
   }
 
   val component = ReactComponentB[Props]("ShellScriptPackageInput")
-    .initialState_P(props => State(props.value.map(_.content)))
+    .initialState_P(props => State(props.value.map(_.content).orElse(Some(DefaultScript))))
     .renderBackend[Backend]
     .configure(Reusability.shouldComponentUpdate)
     .build

--- a/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
@@ -29,11 +29,15 @@ object ShellScriptPackageInput {
   @inline private def lnf = lookAndFeel
 
   final val DefaultScript =
-    """
-      |#!/bin/bash
+    """#!/bin/bash
       |
-      |echo "Hello World"
-    """.stripMargin
+      |echo "Hello World"""".stripMargin
+
+  final val EditorOptions = CodeEditor.Options(
+    mode = Some(CodeEditor.Mode.Shell),
+    lineNumbers = true,
+    theme = Set(CodeEditor.ThemeStyle.Solarized, CodeEditor.ThemeStyle.Light)
+  )
 
   type OnUpdate = Option[ShellScriptPackage] => Callback
 
@@ -55,8 +59,12 @@ object ShellScriptPackageInput {
       <.div(lnf.formGroup,
         <.label(^.`class` := "col-sm-2 control-label", ^.`for` := "script_content", "Script"),
         <.div(^.`class` := "col-sm-10",
-          //TextArea(state.content, onContentUpdate, ^.id := "script_content")
-          CodeEditor(state.content, onContentUpdate, ^.id := "script_content")
+          CodeEditor(state.content,
+            onContentUpdate _,
+            EditorOptions,
+            ^.id := "script_content",
+            ^.height := 250
+          )
         )
       )
     }

--- a/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/ShellScriptPackageInput.scala
@@ -36,6 +36,7 @@ object ShellScriptPackageInput {
   final val EditorOptions = CodeEditor.Options(
     mode = Some(CodeEditor.Mode.Shell),
     lineNumbers = true,
+    matchBrackets = true,
     theme = Set(CodeEditor.ThemeStyle.Solarized, CodeEditor.ThemeStyle.Light)
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -81,6 +81,7 @@ object Dependencies {
     val fontAwesome      = "4.7.0"
     val reactJs          = "15.4.2"
     val sparkMD5         = "2.0.2"
+    val codemirror       = "5.24.2"
   }
 
   // Common library definitions
@@ -240,6 +241,13 @@ object Dependencies {
       "com.github.japgolly.test-state" %%% "ext-scalaz"        % version.testState % Test
     ),
     jsDependencies ++= Seq(
+      // CodeMirror
+      "org.webjars" % "codemirror" % version.codemirror
+        / "lib/codemirror.js"
+        commonJSName "CodeMirror",
+      "org.webjars" % "codemirror" % version.codemirror
+        / "mode/shell/shell.js",
+
       // ReactJS
       "org.webjars.bower" % "react" % version.reactJs
         /        "react-with-addons.js"
@@ -294,6 +302,7 @@ object Dependencies {
       "com.vmunier"      %% "scalajs-scripts" % version.scalaJSScripts,
       "org.webjars"       % "bootstrap-sass"  % version.bootstrap,
       "org.webjars"       % "font-awesome"    % version.fontAwesome,
+      "org.webjars"       % "codemirror"      % version.codemirror,
       "org.webjars.bower" % "animatewithsass" % version.animate
     )
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "0.5.4")
 // Web plugins
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
 addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.3")
-addSbtPlugin("org.madoushi.sbt" % "sbt-sass" % "0.9.3")
+addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.8")
 addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.0")
 
 // Server side plugins

--- a/util/js/src/main/scala/io/quckoo/md5/MD5_js.scala
+++ b/util/js/src/main/scala/io/quckoo/md5/MD5_js.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.quckoo.md5
 
 import scala.scalajs.js.typedarray._

--- a/util/jvm/src/main/scala/io/quckoo/md5/MD5_jvm.scala
+++ b/util/jvm/src/main/scala/io/quckoo/md5/MD5_jvm.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Antonio Alonso Dominguez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.quckoo.md5
 
 import java.security.MessageDigest


### PR DESCRIPTION
Adds a source code editor in the Job Spec form when registering shell script jobs. The code editor is backed by CodeMirror and fully integrated as a React component in the UI.

In order to have full support for the editor themes and syntaxes, the sbt-sass plugin has been replaced by sbt-sassify, which happens to be more up to date (able to merge CSS files with SCSS files) but also compiles the final CSS file much faster.