### PR TITLE
Display details for execution plans

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,10 @@ lazy val commonSettings = Seq(
     botBuild := scala.sys.env.get("TRAVIS").isDefined
   ) ++ Licensing.settings
 
+lazy val commonJvmSettings = Seq(
+  fork in Test := true
+)
+
 lazy val commonJsSettings = Seq(
   coverageEnabled := false,
   coverageExcludedFiles := ".*",
@@ -167,6 +171,7 @@ lazy val core = (crossProject.crossType(CrossType.Pure) in file("core"))
   .settings(publishSettings: _*)
   .settings(Dependencies.core: _*)
   .jsSettings(commonJsSettings: _*)
+  .jvmSettings(commonJvmSettings: _*)
   .settings(
     name := "core",
     moduleName := "quckoo-core",
@@ -188,6 +193,7 @@ lazy val api = (crossProject.crossType(CrossType.Pure) in file("api"))
   .settings(publishSettings: _*)
   .settings(Dependencies.api: _*)
   .jsSettings(commonJsSettings: _*)
+  .jvmSettings(commonJvmSettings: _*)
   .settings(
     name := "api",
     moduleName := "quckoo-api"
@@ -207,6 +213,7 @@ lazy val client = (crossProject in file("client"))
   .settings(Dependencies.client: _*)
   .jsSettings(commonJsSettings: _*)
   .jsSettings(Dependencies.clientJS: _*)
+  .jvmSettings(commonJvmSettings: _*)
   .jvmSettings(Dependencies.clientJVM: _*)
   .settings(
     name := "client",
@@ -239,6 +246,7 @@ lazy val console = (project in file("console"))
 lazy val shared = (project in file("shared"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
+  .settings(commonJvmSettings)
   .settings(scoverageSettings)
   .settings(publishSettings: _*)
   .settings(Dependencies.clusterShared)
@@ -256,13 +264,14 @@ lazy val master = (project in file("master"))
     DockerPlugin
   )
   .configs(MultiJvm)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
+  .settings(commonJvmSettings)
   .settings(scoverageSettings)
-  .settings(publishSettings: _*)
-  .settings(Revolver.settings: _*)
+  .settings(publishSettings)
+  .settings(Revolver.settings)
   .settings(Dependencies.clusterMaster)
   .settings(MultiNode.settings)
-  .settings(Packaging.masterSettings: _*)
+  .settings(Packaging.masterSettings)
   .settings(
     moduleName := "quckoo-master",
     scalaJSProjects := Seq(console),
@@ -278,6 +287,7 @@ lazy val master = (project in file("master"))
 lazy val worker = (project in file("worker"))
   .enablePlugins(AutomateHeaderPlugin, JavaServerAppPackaging, DockerPlugin)
   .settings(commonSettings: _*)
+  .settings(commonJvmSettings)
   .settings(scoverageSettings)
   .settings(publishSettings: _*)
   .settings(Revolver.settings: _*)
@@ -295,6 +305,7 @@ lazy val util = (crossProject in file("util"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .jsSettings(Dependencies.utilJS)
+  .jvmSettings(commonJvmSettings: _*)
   .settings(moduleName := "quckoo-util")
   .dependsOn(testSupport % Test)
 
@@ -309,6 +320,7 @@ lazy val testSupport = (crossProject in file("test-support"))
   .settings(noPublishSettings: _*)
   .settings(Dependencies.testSupport: _*)
   .jsSettings(commonJsSettings: _*)
+  .jvmSettings(commonJvmSettings: _*)
   .jvmSettings(Dependencies.testSupportJVM: _*)
   .settings(
     name := "test-support",
@@ -327,8 +339,9 @@ lazy val examples = (project in file("examples"))
 
 lazy val exampleJobs = (project in file("examples/jobs"))
   .enablePlugins(AutomateHeaderPlugin)
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
+  .settings(commonSettings)
+  .settings(commonJvmSettings)
+  .settings(publishSettings)
   .settings(Dependencies.exampleJobs)
   .settings(
     name := "example-jobs",
@@ -338,11 +351,12 @@ lazy val exampleJobs = (project in file("examples/jobs"))
 
 lazy val exampleProducers = (project in file("examples/producers"))
   .enablePlugins(AutomateHeaderPlugin, JavaAppPackaging, DockerPlugin)
-  .settings(commonSettings: _*)
-  .settings(publishSettings: _*)
-  .settings(Revolver.settings: _*)
+  .settings(commonSettings)
+  .settings(commonJvmSettings)
+  .settings(publishSettings)
+  .settings(Revolver.settings)
   .settings(Dependencies.exampleProducers)
-  .settings(Packaging.exampleProducersSettings: _*)
+  .settings(Packaging.exampleProducersSettings)
   .settings(
     name := "example-producers",
     moduleName := "quckoo-example-producers"

--- a/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
+++ b/console/src/main/scala/io/quckoo/console/components/CodeEditor.scala
@@ -107,11 +107,11 @@ object CodeEditor {
     protected[CodeEditor] def initialize(props: Props, state: State): Callback = Callback {
       val codeMirror = CodeMirror($.getDOMNode(), jsOptions(props))
 
-      codeMirror.setValue(props.text.getOrElse(""))
-      codeMirror.setSize(props.width, props.height)
-
       codeMirror.on("change", (cm, event) => onChange(cm, event.asInstanceOf[ChangeEvent]))
       codeMirror.on("blur", (cm, event) => onBlur(cm, event.asInstanceOf[Event]))
+
+      codeMirror.setValue(props.text.getOrElse(""))
+      codeMirror.setSize(props.width, props.height)
 
       codeMirror.refresh()
       codeMirror.markClean()
@@ -121,12 +121,12 @@ object CodeEditor {
       $.modState(_.copy(value = editorValue), propagateUpdate).runNow()
     }
 
-    def onBlur(codeMirror: CodeMirror, event: Event): Unit = {
+    private[this] def onBlur(codeMirror: CodeMirror, event: Event): Unit = {
       val editorValue = Option(codeMirror.getValue()).filterNot(_.isEmpty)
       valueUpdated(editorValue)
     }
 
-    def onChange(codeMirror: CodeMirror, change: ChangeEvent): Unit = {
+    private[this] def onChange(codeMirror: CodeMirror, change: ChangeEvent): Unit = {
       val editorValue = Option(codeMirror.getValue()).filterNot(_.isEmpty)
       if (!editorValue.contains(change.removed.mkString("\n")))
         valueUpdated(editorValue)

--- a/console/src/main/scala/io/quckoo/console/components/CoproductSelect.scala
+++ b/console/src/main/scala/io/quckoo/console/components/CoproductSelect.scala
@@ -110,14 +110,14 @@ object CoproductSelect {
 
 }
 
-class CoproductSelect[A: Reusability] private[components](mapper: CoproductSelect.ValueMapper[A]) {
+final class CoproductSelect[A: Reusability] private[components](mapper: CoproductSelect.ValueMapper[A]) {
   import CoproductSelect._
 
-  private def generateState(props: Props[A], cache: Map[Symbol, A] = Map.empty): State[A] = {
+  private def generateState(props: Props[A]): State[A] = {
     val selectedSymbol = props.value.flatMap(mapper.lift)
     val rebuiltCache   = selectedSymbol.zip(props.value).map {
-      case (sym, value) => cache + (sym -> value)
-    }.headOption.getOrElse(cache)
+      case (sym, value) => Map(sym -> value)
+    }.headOption.getOrElse(Map.empty[Symbol, A])
 
     State[A](
       selected = selectedSymbol,

--- a/console/src/main/scala/io/quckoo/console/components/FiniteDurationInput.scala
+++ b/console/src/main/scala/io/quckoo/console/components/FiniteDurationInput.scala
@@ -81,8 +81,8 @@ object FiniteDurationInput {
       $.modState(_.copy(unit = value), propagateUpdate)
     }
 
-    private[this] val _lengthInput = Input[Long]()
-    private[this] val validateLength = {
+    private[this] val _lengthInput = Input[Long]
+    private[this] val LengthValidation = {
       import Scalaz._
       ValidatedInput[Long]((greaterThan(0L) or equalTo(0L)).callback)
     }
@@ -96,7 +96,7 @@ object FiniteDurationInput {
         ^.`class` := "container-fluid",
         <.div(
           ^.`class` := "row",
-          <.div(^.`class` := "col-sm-4", validateLength(onLengthUpdate _)(lengthInput(props, state))),
+          <.div(^.`class` := "col-sm-4", LengthValidation(onLengthUpdate _)(lengthInput(props, state))),
           <.div(
             ^.`class` := "col-sm-6",
             <.select(

--- a/console/src/main/scala/io/quckoo/console/components/FiniteDurationInput.scala
+++ b/console/src/main/scala/io/quckoo/console/components/FiniteDurationInput.scala
@@ -44,7 +44,8 @@ object FiniteDurationInput {
 
   case class Props(id: String,
                    value: Option[FiniteDuration],
-                   onUpdate: Option[FiniteDuration] => Callback)
+                   onUpdate: Option[FiniteDuration] => Callback,
+                   readOnly: Boolean = false)
   case class State(length: Option[Long], unit: Option[TimeUnit]) {
 
     def this(duration: Option[FiniteDuration]) =
@@ -80,14 +81,14 @@ object FiniteDurationInput {
       $.modState(_.copy(unit = value), propagateUpdate)
     }
 
-    val _lengthInput = Input[Long]()
-    val validateLength = {
+    private[this] val _lengthInput = Input[Long]()
+    private[this] val validateLength = {
       import Scalaz._
       ValidatedInput[Long]((greaterThan(0L) or equalTo(0L)).callback)
     }
 
-    def lengthInput(id: String, state: State)(onUpdate: Option[Long] => Callback) =
-      _lengthInput(state.length, onUpdate, ^.id := s"${id}_length")
+    private[this] def lengthInput(props: Props, state: State)(onUpdate: Option[Long] => Callback) =
+      _lengthInput(state.length, onUpdate, ^.id := s"${props.id}_length", ^.readOnly := props.readOnly)
 
     def render(props: Props, state: State) = {
       val id = props.id
@@ -95,12 +96,14 @@ object FiniteDurationInput {
         ^.`class` := "container-fluid",
         <.div(
           ^.`class` := "row",
-          <.div(^.`class` := "col-sm-4", validateLength(onLengthUpdate _)(lengthInput(id, state))),
+          <.div(^.`class` := "col-sm-4", validateLength(onLengthUpdate _)(lengthInput(props, state))),
           <.div(
             ^.`class` := "col-sm-6",
             <.select(
               ^.id := s"${id}_unit",
               ^.`class` := "form-control",
+              ^.readOnly := props.readOnly,
+              ^.disabled := props.readOnly,
               state.unit.map(u => ^.value := u.toString()),
               ^.onChange ==> onUnitUpdate,
               <.option(^.value := "", "Select a time unit..."),
@@ -124,7 +127,8 @@ object FiniteDurationInput {
 
   def apply(id: String,
             value: Option[FiniteDuration],
-            onUpdate: Option[FiniteDuration] => Callback) =
-    component(Props(id, value, onUpdate))
+            onUpdate: Option[FiniteDuration] => Callback,
+            readOnly: Boolean = false) =
+    component(Props(id, value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/components/Input.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Input.scala
@@ -35,7 +35,7 @@ object Input {
     def to: A => String
   }
   object Converter {
-    abstract sealed class BaseConverter[A] extends Converter[A] {
+    private abstract sealed class BaseConverter[A] extends Converter[A] {
       override def to: A => String = _.toString
     }
 
@@ -46,7 +46,7 @@ object Input {
 
     implicit val password: Converter[Password] = new Converter[Password] {
       def to: Password => String   = _.value
-      def from: String => Password = new Password(_)
+      def from: String => Password = Password(_)
     }
 
     implicit val int: Converter[Int] = new BaseConverter[Int] {
@@ -55,6 +55,10 @@ object Input {
 
     implicit val long: Converter[Long] = new BaseConverter[Long] {
       override def from: String => Long = _.toLong
+    }
+
+    implicit val short: Converter[Short] = new BaseConverter[Short] {
+      override def from: String => Short = _.toShort
     }
 
     implicit val date: Converter[LocalDate] = new BaseConverter[LocalDate] {
@@ -74,6 +78,7 @@ object Input {
     implicit val password = new Type[Password]("password") {}
     implicit val int      = new Type[Int]("number")        {}
     implicit val long     = new Type[Long]("number")       {}
+    implicit val short    = new Type[Short]("number")      {}
     implicit val date     = new Type[LocalDate]("date")    {}
     implicit val time     = new Type[LocalTime]("time")    {}
   }
@@ -118,7 +123,7 @@ object Input {
 
   }
 
-  def apply[A: Reusability]() = new Input[A]
+  def apply[A: Reusability] = new Input[A]
 
 }
 

--- a/console/src/main/scala/io/quckoo/console/components/Modal.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Modal.scala
@@ -95,11 +95,11 @@ object Modal {
     }
   }
 
-  val component = ReactComponentB[Props]("Modal")
+  val Component = ReactComponentB[Props]("Modal")
     .renderBackend[Backend]
     .componentDidMount($ => $.backend.initialize($.props))
     .build
 
-  def apply()                                   = component
-  def apply(props: Props, children: ReactNode*) = component(props, children: _*)
+  def apply()                                   = Component
+  def apply(props: Props, children: ReactNode*) = Component(props, children: _*)
 }

--- a/console/src/main/scala/io/quckoo/console/components/Password.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Password.scala
@@ -24,5 +24,7 @@ import japgolly.scalajs.react.extra.Reusability
 final class Password(val value: String) extends AnyVal
 
 object Password {
+  def apply(value: String): Password = new Password(value)
+
   implicit val reusability: Reusability[Password] = Reusability.by(_.value)
 }

--- a/console/src/main/scala/io/quckoo/console/components/Table.scala
+++ b/console/src/main/scala/io/quckoo/console/components/Table.scala
@@ -162,8 +162,10 @@ object Table {
         }
       } getOrElse props.items
 
-    def allSelected(props: Props[Id, Item], state: State[Id]): Boolean =
-      visibleItems(props).map(_._1).forall(state.selected.contains)
+    def allSelected(props: Props[Id, Item], state: State[Id]): Boolean = {
+      val items = visibleItems(props)
+      items.nonEmpty && items.map(_._1).forall(state.selected.contains)
+    }
 
     def toggleSelectAll(props: Props[Id, Item]): Callback = {
       def updateState(state: State[Id]): State[Id] = {

--- a/console/src/main/scala/io/quckoo/console/core/ConsoleOps.scala
+++ b/console/src/main/scala/io/quckoo/console/core/ConsoleOps.scala
@@ -92,7 +92,7 @@ private[core] trait ConsoleOps { this: LoggerHolder =>
       logger.debug("Loading all jobs from the server...")
       client.fetchJobs.map(_.map { case (k, v) => (k, Ready(v)) })
     } else {
-      logger.debug("Loading job specs for keys: {}", keys.mkString(", "))
+      logger.debug("Loading job specs for ids: {}", keys.mkString(", "))
       Future.sequence(keys.map(loadJobSpec)).map(_.toMap)
     }
   }
@@ -119,8 +119,10 @@ private[core] trait ConsoleOps { this: LoggerHolder =>
   ): Future[Map[PlanId, Pot[ExecutionPlan]]] = {
     implicit val timeout = DefaultTimeout
     if (ids.isEmpty) {
+      logger.debug("Loading all execution plans from the server")
       client.executionPlans.map(_.map { case (k, v) => (k, Ready(v)) })
     } else {
+      logger.debug("Loading execution plans for ids: {}", ids.mkString(", "))
       Future.sequence(ids.map(loadPlan)).map(_.toMap)
     }
   }

--- a/console/src/main/scala/io/quckoo/console/registry/ArtifactInput.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/ArtifactInput.scala
@@ -62,9 +62,9 @@ object ArtifactInput {
     def onVersionUpdate(version: Option[String]): Callback =
       $.modState(_.copy(version = version), propagateUpdate)
 
-    val organizationInput = Input[String]()
-    val nameInput         = Input[String]()
-    val versionInput      = Input[String]()
+    private[this] val OrganizationInput = Input[String]
+    private[this] val NameInput         = Input[String]
+    private[this] val VersionInput      = Input[String]
 
     def render(props: Props, state: State) = {
       <.div(
@@ -73,7 +73,7 @@ object ArtifactInput {
           ^.`class` := "row",
           <.div(
             ^.`class` := "col-sm-4",
-            organizationInput(
+            OrganizationInput(
               state.organization,
               onGroupUpdate _,
               ^.id := "artifactOrganization",
@@ -82,7 +82,7 @@ object ArtifactInput {
             )),
           <.div(
             ^.`class` := "col-sm-4",
-            nameInput(
+            NameInput(
               state.name,
               onNameUpdate _,
               ^.id := "artifactName",
@@ -91,7 +91,7 @@ object ArtifactInput {
             )),
           <.div(
             ^.`class` := "col-sm-4",
-            versionInput(
+            VersionInput(
               state.version,
               onVersionUpdate _,
               ^.id := "artifactVerion",

--- a/console/src/main/scala/io/quckoo/console/registry/JarJobPackageInput.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JarJobPackageInput.scala
@@ -45,7 +45,6 @@ object JarJobPackageInput {
   implicit val stateReuse: Reusability[State] = Reusability.caseClass[State]
 
   class Backend($: BackendScope[Props, State]) {
-    private[this] val jobClassInput = Input[String]()
 
     private[this] def propagateChange: Callback = {
       val jarPackage = for {
@@ -62,6 +61,8 @@ object JarJobPackageInput {
     def onJobClassUpdate(value: Option[String]): Callback =
       $.modState(_.copy(jobClass = value), propagateChange)
 
+    private[this] val JobClassInput = Input[String]
+
     def render(props: Props, state: State) = {
       <.div(
         <.div(lnf.formGroup,
@@ -73,7 +74,7 @@ object JarJobPackageInput {
         <.div(lnf.formGroup,
           <.label(^.`class` := "col-sm-2 control-label", ^.`for` := "jobClass", "Job Class"),
           <.div(^.`class` := "col-sm-10",
-            jobClassInput(state.jobClass,
+            JobClassInput(state.jobClass,
               onJobClassUpdate _,
               ^.id := "jobClass",
               ^.placeholder := "Job main class",

--- a/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
@@ -155,13 +155,10 @@ object JobForm {
 
   }
 
-  private[registry] val component = ReactComponentB[Props]("JobForm").
-    initialState_P(p => State(new EditableJobSpec(None))).
-    renderBackend[Backend].
-    build
-
-  def apply(handler: Handler) =
-    component(Props(handler))
+  private[registry] val component = ReactComponentB[Props]("JobForm")
+    .initialState(State(new EditableJobSpec(None)))
+    .renderBackend[Backend]
+    .build
 
   def apply(handler: Handler, refName: String) =
     component.withRef(refName)(Props(handler))

--- a/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
@@ -68,7 +68,7 @@ object JobForm {
 
     // Event handlers
 
-    def onModalClosed(props: Props) = {
+    def onModalClosed(props: Props): Callback = {
       def jobSpec(state: State): Option[JobSpec] = if (!state.cancelled) {
         for {
           name  <- state.spec.displayName
@@ -76,16 +76,16 @@ object JobForm {
         } yield JobSpec(name, state.spec.description, pckg)
       } else None
 
-      $.state.map(jobSpec) >>= props.handler
+      $.modState(_.copy(visible = false)) >> $.state.map(jobSpec) >>= props.handler
     }
 
     // Actions
 
     def submitForm(): Callback =
-      $.modState(_.copy(visible = false, cancelled = false))
+      $.modState(_.copy(cancelled = false))
 
     def editJob(jobSpec: Option[JobSpec]): Callback =
-      $.modState(_.copy(spec = new EditableJobSpec(jobSpec), visible = true, readOnly = jobSpec.isDefined))
+      $.setState(State(spec = new EditableJobSpec(jobSpec), visible = true, readOnly = jobSpec.isDefined))
 
     // Rendering
 

--- a/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
@@ -89,8 +89,8 @@ object JobForm {
 
     // Rendering
 
-    val displayNameInput = Input[String]()
-    val descriptionInput = Input[String]()
+    private[this] val DisplayNameInput = Input[String]
+    private[this] val DescriptionInput = Input[String]
 
     def render(props: Props, state: State) = {
       <.form(^.name := "jobDetails", ^.`class` := "form-horizontal",
@@ -117,7 +117,7 @@ object JobForm {
             <.div(lnf.formGroup,
               <.label(^.`class` := "col-sm-2 control-label", ^.`for` := "displayName", "Display Name"),
               <.div(^.`class` := "col-sm-10",
-                displayNameInput(
+                DisplayNameInput(
                   state.spec.displayName,
                   $.setStateL(displayName)(_),
                   ^.id := "displayName",
@@ -129,7 +129,7 @@ object JobForm {
             <.div(lnf.formGroup,
               <.label(^.`class` := "col-sm-2 control-label", ^.`for` := "description", "Description"),
               <.div(^.`class` := "col-sm-10",
-                descriptionInput(
+                DescriptionInput(
                   state.spec.description,
                   $.setStateL(description)(_),
                   ^.id := "description",

--- a/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobForm.scala
@@ -16,7 +16,7 @@
 
 package io.quckoo.console.registry
 
-import io.quckoo.{JobSpec, JobPackage}
+import io.quckoo.{JobPackage, JobSpec}
 import io.quckoo.console.components._
 
 import japgolly.scalajs.react._

--- a/console/src/main/scala/io/quckoo/console/registry/JobPackageSelect.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobPackageSelect.scala
@@ -30,7 +30,7 @@ object JobPackageSelect {
   type Selector    = CoproductSelect.Selector[JobPackage]
   type OnUpdate    = CoproductSelect.OnUpdate[JobPackage]
 
-  final case class Props(value: Option[JobPackage], readOnly: Boolean, onUpdate: OnUpdate)
+  final case class Props(value: Option[JobPackage], onUpdate: OnUpdate, readOnly: Boolean = false)
 
   class Backend($: BackendScope[Props, Unit]) {
 
@@ -41,14 +41,14 @@ object JobPackageSelect {
         ShellScriptPackageInput(value.map(_.asInstanceOf[ShellScriptPackage]), update, props.readOnly)
     }
 
-    val selectInput = CoproductSelect[JobPackage] {
+    private[this] val selectInput = CoproductSelect[JobPackage] {
       case _: JarJobPackage      => 'Jar
       case _: ShellScriptPackage => 'Shell
     }
 
     def render(props: Props) = {
       selectInput(Options, selectComponent(props), props.value, props.onUpdate,
-        ^.id := "packageType", ^.readOnly := props.readOnly
+        ^.id := "packageType", ^.readOnly := props.readOnly, ^.disabled := props.readOnly
       )(<.label(^.`class` := "col-sm-2 control-label", ^.`for` := "packageType", "Package Type"))
     }
 
@@ -60,6 +60,6 @@ object JobPackageSelect {
     .build
 
   def apply(value: Option[JobPackage], onUpdate: OnUpdate, readOnly: Boolean = false) =
-    component(Props(value, readOnly, onUpdate))
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/registry/JobSelect.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobSelect.scala
@@ -32,7 +32,8 @@ object JobSelect {
 
   case class Props(jobs: Map[JobId, JobSpec],
                    value: Option[JobId],
-                   onUpdate: Option[JobId] => Callback)
+                   onUpdate: Option[JobId] => Callback,
+                   readOnly: Boolean = false)
 
   private[this] val JobOption = ReactComponentB[(JobId, JobSpec)]("JobOption").stateless.render_P {
     case (jobId, spec) =>
@@ -60,6 +61,8 @@ object JobSelect {
             ^.id := "jobId",
             props.value.map(id => ^.value := id.toString()),
             ^.onChange ==> onUpdate,
+            ^.readOnly := props.readOnly,
+            ^.disabled := props.readOnly,
             <.option("Select a job"),
             props.jobs
               .filter(!_._2.disabled)
@@ -68,9 +71,14 @@ object JobSelect {
 
   }
 
-  val component = ReactComponentB[Props]("JobSelect").stateless.renderBackend[Backend].build
+  val Component = ReactComponentB[Props]("JobSelect")
+    .stateless
+    .renderBackend[Backend]
+    .build
 
-  def apply(jobs: Map[JobId, JobSpec], value: Option[JobId], onUpdate: Option[JobId] => Callback) =
-    component(Props(jobs, value, onUpdate))
+  def apply(jobs: Map[JobId, JobSpec],
+            value: Option[JobId],
+            onUpdate: Option[JobId] => Callback,
+            readOnly: Boolean = false) = Component(Props(jobs, value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/registry/JobSpecList.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobSpecList.scala
@@ -63,7 +63,7 @@ object JobSpecList {
 
   class Backend($ : BackendScope[Props, State]) {
 
-    def mounted(props: Props) = {
+    private[JobSpecList] def mounted(props: Props) = {
       def dispatchJobLoading: Callback =
         props.proxy.dispatchCB(LoadJobSpecs)
 
@@ -128,10 +128,10 @@ object JobSpecList {
 
     // Event handlers
 
-    def filterClicked(filterType: Symbol): Callback =
+    def onFilterClicked(filterType: Symbol): Callback =
       $.modState(_.copy(selectedFilter = Some(filterType)))
 
-    def jobClicked(jobId: JobId): Callback = {
+    def onJobClicked(jobId: JobId): Callback = {
       def onJobClickedCB(jobSpec: JobSpec): Callback =
         $.props.flatMap(_.onJobEdit(jobSpec))
 
@@ -143,13 +143,13 @@ object JobSpecList {
       )
     }
 
-    def jobSelected(selection: Set[JobId]): Callback =
+    def onJobSelected(selection: Set[JobId]): Callback =
       $.modState(_.copy(selectedJobs = selection))
 
     // Render methods
 
     private[this] def renderName(jobId: JobId, jobSpec: JobSpec): ReactNode =
-      <.a(^.onClick --> jobClicked(jobId), jobSpec.displayName)
+      <.a(^.onClick --> onJobClicked(jobId), jobSpec.displayName)
 
     def renderItem(jobId: JobId, jobSpec: JobSpec, column: Symbol): ReactNode = column match {
       case 'Name        => renderName(jobId, jobSpec)
@@ -183,12 +183,12 @@ object JobSpecList {
         ),
         NavBar(
           NavBar
-            .Props(List('All, 'Enabled, 'Disabled), 'All, filterClicked, style = NavStyle.pills),
+            .Props(List('All, 'Enabled, 'Disabled), 'All, onFilterClicked, style = NavStyle.pills),
           Table(
             Columns,
             model.seq,
             renderItem,
-            onSelect = Some(jobSelected _),
+            onSelect = Some(onJobSelected _),
             actions = Some(rowActions(props)(_, _)),
             filter = state.selectedFilter.flatMap(Filters.get),
             selected = state.selectedJobs,

--- a/console/src/main/scala/io/quckoo/console/registry/JobSpecList.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/JobSpecList.scala
@@ -52,7 +52,6 @@ object JobSpecList {
 
   type OnCreate = Callback
   type OnClick = JobSpec => Callback
-  type OnSelect = Set[JobId] => Callback
 
   final case class Props(
     proxy: ModelProxy[PotMap[JobId, JobSpec]],

--- a/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
@@ -49,7 +49,7 @@ object RegistryPage {
 
   class Backend($ : BackendScope[Props, Unit]) {
 
-    def jobForm: OptionT[CallbackTo, JobForm.Backend] =
+    lazy val jobForm: OptionT[CallbackTo, JobForm.Backend] =
       OptionT(CallbackTo.lift(() => formRef($).toOption.map(_.backend)))
 
     def editJob(spec: Option[JobSpec]): Callback = {

--- a/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
@@ -53,7 +53,8 @@ object RegistryPage {
       OptionT(CallbackTo.lift(() => formRef($).toOption.map(_.backend)))
 
     def editJob(spec: Option[JobSpec]): Callback = {
-      jobForm.flatMapF(_.editJob(spec)).getOrElseF(Callback.empty)
+      jobForm.flatMapF(_.editJob(spec))
+        .getOrElseF(Callback.log("Reference {} points to nothing!", formRef.name))
     }
 
     def jobEdited(spec: Option[JobSpec]): Callback = {

--- a/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
@@ -40,14 +40,14 @@ object RegistryPage {
 
   }
 
-  case class Props(proxy: ModelProxy[ConsoleScope])
+  final case class Props(proxy: ModelProxy[ConsoleScope])
 
-  private val formRef = Ref.to(JobForm.component, "jobForm")
+  private lazy val formRef = Ref.to(JobForm.component, "jobForm")
 
-  class RegistryBackend($ : BackendScope[Props, Unit]) {
+  class Backend($ : BackendScope[Props, Unit]) {
 
     def editJob(spec: Option[JobSpec]): Callback = {
-      formRef($).map(_.backend.editJob(spec)).getOrElse(Callback.empty)
+      formRef($.refs).map(_.backend.editJob(spec)).getOrElse(Callback.empty)
     }
 
     def jobEdited(spec: Option[JobSpec]): Callback = {
@@ -75,7 +75,7 @@ object RegistryPage {
 
   private[this] val component = ReactComponentB[Props]("RegistryPage")
     .stateless
-    .renderBackend[RegistryBackend]
+    .renderBackend[Backend]
     .build
 
   def apply(proxy: ModelProxy[ConsoleScope]) = component(Props(proxy))

--- a/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
@@ -28,10 +28,13 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 import scalacss.Defaults._
 import scalacss.ScalaCssReact._
 
+import scalaz.OptionT
+
 /**
   * Created by alonsodomin on 17/10/2015.
   */
 object RegistryPage {
+  import ScalazReact._
 
   object Style extends StyleSheet.Inline {
     import dsl._
@@ -46,8 +49,11 @@ object RegistryPage {
 
   class Backend($ : BackendScope[Props, Unit]) {
 
-    def editJob(spec: Option[JobSpec]): Callback = Callback {
-      formRef($).get.backend.editJob(spec).runNow()
+    def jobForm: OptionT[CallbackTo, JobForm.Backend] =
+      OptionT(CallbackTo.lift(() => formRef($).toOption.map(_.backend)))
+
+    def editJob(spec: Option[JobSpec]): Callback = {
+      jobForm.flatMapF(_.editJob(spec)).getOrElseF(Callback.empty)
     }
 
     def jobEdited(spec: Option[JobSpec]): Callback = {

--- a/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
+++ b/console/src/main/scala/io/quckoo/console/registry/RegistryPage.scala
@@ -46,8 +46,8 @@ object RegistryPage {
 
   class Backend($ : BackendScope[Props, Unit]) {
 
-    def editJob(spec: Option[JobSpec]): Callback = {
-      formRef($.refs).map(_.backend.editJob(spec)).getOrElse(Callback.empty)
+    def editJob(spec: Option[JobSpec]): Callback = Callback {
+      formRef($).get.backend.editJob(spec).runNow()
     }
 
     def jobEdited(spec: Option[JobSpec]): Callback = {

--- a/console/src/main/scala/io/quckoo/console/scheduler/AfterTriggerInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/AfterTriggerInput.scala
@@ -30,7 +30,7 @@ import scala.concurrent.duration.FiniteDuration
   */
 object AfterTriggerInput {
 
-  case class Props(value: Option[Trigger.After], onUpdate: Option[Trigger.After] => Callback)
+  case class Props(value: Option[Trigger.After], onUpdate: Option[Trigger.After] => Callback, readOnly: Boolean)
   implicit val propsReuse = Reusability.by[Props, Option[Trigger.After]](_.value)
 
   class Backend($ : BackendScope[Props, Unit]) {
@@ -44,7 +44,7 @@ object AfterTriggerInput {
         <.label(^.`class` := "col-sm-2 control-label", "Delay"),
         <.div(
           ^.`class` := "col-sm-10",
-          FiniteDurationInput("afterTrigger", props.value.map(_.delay), onUpdate)))
+          FiniteDurationInput("afterTrigger", props.value.map(_.delay), onUpdate, props.readOnly)))
 
   }
 
@@ -53,7 +53,7 @@ object AfterTriggerInput {
     .configure(Reusability.shouldComponentUpdate)
     .build
 
-  def apply(value: Option[Trigger.After], onUpdate: Option[Trigger.After] => Callback) =
-    component(Props(value, onUpdate))
+  def apply(value: Option[Trigger.After], onUpdate: Option[Trigger.After] => Callback, readOnly: Boolean = false) =
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/scheduler/AtTriggerInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/AtTriggerInput.scala
@@ -57,19 +57,19 @@ object AtTriggerInput {
     def onTimeUpdate(value: Option[LocalTime]): Callback =
       $.modState(_.copy(time = value), propagateUpdate)
 
-    private[this] val dateInput = Input[LocalDate]()
-    private[this] val timeInput = Input[LocalTime]()
+    private[this] val DateInput = Input[LocalDate]
+    private[this] val TimeInput = Input[LocalTime]
 
     def render(props: Props, state: State) = {
       <.div(
         <.div(
           ^.`class` := "form-group",
           <.label(^.`class` := "col-sm-2 control-label", "Date"),
-          <.div(^.`class` := "col-sm-10", dateInput(state.date, onDateUpdate _, ^.readOnly := props.readOnly))),
+          <.div(^.`class` := "col-sm-10", DateInput(state.date, onDateUpdate _, ^.readOnly := props.readOnly))),
         <.div(
           ^.`class` := "form-group",
           <.label(^.`class` := "col-sm-2 control-label", "Time"),
-          <.div(^.`class` := "col-sm-10", timeInput(state.time, onTimeUpdate _, ^.readOnly := props.readOnly)))
+          <.div(^.`class` := "col-sm-10", TimeInput(state.time, onTimeUpdate _, ^.readOnly := props.readOnly)))
       )
     }
 

--- a/console/src/main/scala/io/quckoo/console/scheduler/CronTriggerInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/CronTriggerInput.scala
@@ -76,7 +76,7 @@ object CronTriggerInput {
     def onUpdate(value: Option[String]) =
       $.modState(_.copy(inputExpr = value)) >> doValidate(value)
 
-    private[this] val expressionInput = Input[String]()
+    private[this] val ExpressionInput = Input[String]
 
     def render(props: Props, state: State) = {
       <.div(
@@ -84,7 +84,7 @@ object CronTriggerInput {
         <.label(^.`class` := "col-sm-2 control-label", "Expression"),
         <.div(
           ^.`class` := "col-sm-10",
-          expressionInput(state.inputExpr, onUpdate _, ^.id := "cronTrigger", ^.readOnly := props.readOnly)),
+          ExpressionInput(state.inputExpr, onUpdate _, ^.id := "cronTrigger", ^.readOnly := props.readOnly)),
         <.div(
           ^.`class` := "col-sm-offset-2",
           state.inputExpr.zip(state.errorReason).map(p => errorMessage.withKey("cronError")(p))))

--- a/console/src/main/scala/io/quckoo/console/scheduler/CronTriggerInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/CronTriggerInput.scala
@@ -52,7 +52,7 @@ object CronTriggerInput {
         )
       } build
 
-  case class Props(value: Option[Trigger.Cron], onUpdate: Option[Trigger.Cron] => Callback)
+  case class Props(value: Option[Trigger.Cron], onUpdate: Option[Trigger.Cron] => Callback, readOnly: Boolean)
   case class State(inputExpr: Option[String], errorReason: Option[InvalidCron] = None)
 
   class Backend($ : BackendScope[Props, State]) {
@@ -76,7 +76,7 @@ object CronTriggerInput {
     def onUpdate(value: Option[String]) =
       $.modState(_.copy(inputExpr = value)) >> doValidate(value)
 
-    val expressionInput = Input[String]()
+    private[this] val expressionInput = Input[String]()
 
     def render(props: Props, state: State) = {
       <.div(
@@ -84,7 +84,7 @@ object CronTriggerInput {
         <.label(^.`class` := "col-sm-2 control-label", "Expression"),
         <.div(
           ^.`class` := "col-sm-10",
-          expressionInput(state.inputExpr, onUpdate _, ^.id := "cronTrigger")),
+          expressionInput(state.inputExpr, onUpdate _, ^.id := "cronTrigger", ^.readOnly := props.readOnly)),
         <.div(
           ^.`class` := "col-sm-offset-2",
           state.inputExpr.zip(state.errorReason).map(p => errorMessage.withKey("cronError")(p))))
@@ -97,7 +97,7 @@ object CronTriggerInput {
     .renderBackend[Backend]
     .build
 
-  def apply(value: Option[Trigger.Cron], onUpdate: Option[Trigger.Cron] => Callback) =
-    component(Props(value, onUpdate))
+  def apply(value: Option[Trigger.Cron], onUpdate: Option[Trigger.Cron] => Callback, readOnly: Boolean = false) =
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/scheduler/EveryTriggerInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/EveryTriggerInput.scala
@@ -33,7 +33,7 @@ import scalacss.ScalaCssReact._
 object EveryTriggerInput {
   @inline private def lnf = lookAndFeel
 
-  case class Props(value: Option[Trigger.Every], onUpdate: Option[Trigger.Every] => Callback)
+  case class Props(value: Option[Trigger.Every], onUpdate: Option[Trigger.Every] => Callback, readOnly: Boolean)
   case class State(freq: Option[FiniteDuration], delay: Option[FiniteDuration], delayEnabled: Boolean = false) {
 
     def this(trigger: Option[Trigger.Every]) =
@@ -41,8 +41,8 @@ object EveryTriggerInput {
 
   }
 
-  implicit val propsReuse = Reusability.by[Props, Option[Trigger.Every]](_.value)
-  implicit val stateReuse = Reusability.caseClass[State]
+  implicit val propsReuse: Reusability[Props] = Reusability.caseClassExcept('onUpdate)
+  implicit val stateReuse: Reusability[State] = Reusability.caseClass
 
   class Backend($ : BackendScope[Props, State]) {
 
@@ -76,7 +76,7 @@ object EveryTriggerInput {
           <.label(^.`class` := "col-sm-2 control-label", "Frequency"),
           <.div(
             ^.`class` := "col-sm-10",
-            FiniteDurationInput("everyTrigger_freq", state.freq, onFreqUpdate))),
+            FiniteDurationInput("everyTrigger_freq", state.freq, onFreqUpdate, props.readOnly))),
         <.div(lnf.formGroup,
           <.label(^.`class` := "col-sm-2 control-label", "Delay"),
           <.div(^.`class` := "col-sm-10",
@@ -85,7 +85,9 @@ object EveryTriggerInput {
                 <.input.checkbox(
                   ^.id := "enableDelay",
                   ^.onChange --> onToggleDelay,
-                  ^.value := state.delayEnabled
+                  ^.value := state.delayEnabled,
+                  ^.readOnly := props.readOnly,
+                  ^.disabled := props.readOnly
                 ),
                 "Enabled"
               )
@@ -94,7 +96,7 @@ object EveryTriggerInput {
         ),
         if (state.delayEnabled) {
           <.div(^.`class` := "col-sm-offset-2",
-            FiniteDurationInput("everyTrigger_delay", state.delay, onDelayUpdate)
+            FiniteDurationInput("everyTrigger_delay", state.delay, onDelayUpdate, props.readOnly)
           )
         } else EmptyTag
       )
@@ -108,7 +110,7 @@ object EveryTriggerInput {
     .configure(Reusability.shouldComponentUpdate)
     .build
 
-  def apply(value: Option[Trigger.Every], onUpdate: Option[Trigger.Every] => Callback) =
-    component(Props(value, onUpdate))
+  def apply(value: Option[Trigger.Every], onUpdate: Option[Trigger.Every] => Callback, readOnly: Boolean = false) =
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
@@ -44,7 +44,7 @@ object ExecutionPlanForm {
   @inline
   private def lnf = lookAndFeel
 
-  type ScheduleHandler = Option[ScheduleJob] => Callback
+  type Handler = Option[ScheduleJob] => Callback
 
   @Lenses final case class EditableExecutionPlan(
     jobId: Option[JobId] = None,
@@ -61,13 +61,14 @@ object ExecutionPlanForm {
 
   final case class Props(
       proxy: ModelProxy[PotMap[JobId, JobSpec]],
-      plan: Option[ExecutionPlan],
-      handler: ScheduleHandler
+      handler: Handler
   )
   @Lenses final case class State(
       plan: EditableExecutionPlan,
       timeout: Option[FiniteDuration] = None,
       showPreview: Boolean = false,
+      visible: Boolean = false,
+      readOnly: Boolean = false,
       cancelled: Boolean = true
   )
 
@@ -77,16 +78,12 @@ object ExecutionPlanForm {
     val triggerLens = State.plan ^|-> EditableExecutionPlan.trigger
     val timeoutLens = State.timeout
 
-    def mounted(props: Props) =
+    private[ExecutionPlanForm] def initialize(props: Props) =
       Callback.when(props.proxy().size == 0)(props.proxy.dispatchCB(LoadJobSpecs))
 
-    def togglePreview(): Callback =
-      $.modState(st => st.copy(showPreview = !st.showPreview))
+    // Event handlers
 
-    def submitForm(): Callback =
-      $.modState(_.copy(cancelled = false))
-
-    def formClosed(props: Props, state: State): Callback = {
+    def onModalClosed(props: Props, state: State): Callback = {
       def command: Option[ScheduleJob] = if (!state.cancelled) {
         for {
           jobId <- state.plan.jobId
@@ -94,8 +91,25 @@ object ExecutionPlanForm {
         } yield ScheduleJob(jobId, trigger, state.timeout)
       } else None
 
-      props.handler(command)
+      $.modState(_.copy(visible = false)) >> props.handler(command)
     }
+
+    // Not supported yet
+    def onParamUpdate(name: String, value: String): Callback =
+      Callback.empty
+
+    // Actions
+
+    def togglePreview(): Callback =
+      $.modState(st => st.copy(showPreview = !st.showPreview))
+
+    def submitForm(): Callback =
+      $.modState(_.copy(visible = false, cancelled = false))
+
+    def editPlan(plan: Option[ExecutionPlan]): Callback =
+      $.modState(_.copy(plan = new EditableExecutionPlan(plan), visible = true, readOnly = plan.isDefined))
+
+    // Rendering
 
     def jobSpecs(props: Props): Map[JobId, JobSpec] = {
       props.proxy().seq.flatMap {
@@ -104,52 +118,60 @@ object ExecutionPlanForm {
       } toMap
     }
 
-    // Not supported yet
-    def onParamUpdate(name: String, value: String): Callback =
-      Callback.empty
-
     def render(props: Props, state: State) = {
-      <.form(^.name := "executionPlanForm", ^.`class` := "form-horizontal", Modal(
-        Modal.Props(
-          header = hide => <.span(
-            <.button(^.tpe := "button", lnf.close, ^.onClick --> hide, Icons.close),
-            <.h4("Execution plan")
+      def formHeader(hide: Callback) = {
+        <.span(
+          <.button(^.tpe := "button", lnf.close, ^.onClick --> hide, Icons.close),
+          <.h4("Execution plan")
+        )
+      }
+
+      def formFooter(hide: Callback) = {
+        <.span(
+          Button(Button.Props(Some(hide), style = ContextStyle.default), "Cancel"),
+          Button(Button.Props(Some(togglePreview()), style = ContextStyle.default,
+            disabled = jobIdLens.get(state).isEmpty || triggerLens.get(state).isEmpty),
+            if (state.showPreview) "Back" else "Preview"
           ),
-          footer = hide => <.span(
-            Button(Button.Props(Some(hide), style = ContextStyle.default), "Cancel"),
-            Button(Button.Props(Some(togglePreview()), style = ContextStyle.default,
-              disabled = jobIdLens.get(state).isEmpty || triggerLens.get(state).isEmpty),
-              if (state.showPreview) "Back" else "Preview"
-            ),
-            Button(Button.Props(Some(submitForm() >> hide),
-              disabled = !state.plan.valid,
-              style = ContextStyle.primary), "Ok"
-            )
-          ),
-          onClosed = formClosed(props, state)
-        ),
-        if (!state.showPreview) {
-          <.div(
-            JobSelect(jobSpecs(props), jobIdLens.get(state), $.setStateL(jobIdLens)(_)),
-            TriggerSelect(triggerLens.get(state), $.setStateL(triggerLens)(_)),
-            ExecutionTimeoutInput(timeoutLens.get(state), $.setStateL(timeoutLens)(_))
-            //ExecutionParameterList(Map.empty, onParamUpdate)
+          Button(Button.Props(Some(submitForm() >> hide),
+            disabled = state.readOnly || !state.plan.valid,
+            style = ContextStyle.primary), "Save"
           )
-        } else {
-          triggerLens.get(state).map(ExecutionPlanPreview(_)).get
-        }
-      ))
+        )
+      }
+
+      <.form(^.name := "executionPlanForm", ^.`class` := "form-horizontal",
+        if (state.visible) {
+          Modal(
+            Modal.Props(
+              header = formHeader,
+              footer = formFooter,
+              onClosed = onModalClosed(props, state)
+            ),
+            if (!state.showPreview) {
+              <.div(
+                JobSelect(jobSpecs(props), jobIdLens.get(state), $.setStateL(jobIdLens)(_)),
+                TriggerSelect(triggerLens.get(state), $.setStateL(triggerLens)(_)),
+                ExecutionTimeoutInput(timeoutLens.get(state), $.setStateL(timeoutLens)(_))
+                //ExecutionParameterList(Map.empty, onParamUpdate)
+              )
+            } else {
+              triggerLens.get(state).map(ExecutionPlanPreview(_)).get
+            }
+          )
+        } else EmptyTag
+      )
     }
 
   }
 
-  val component = ReactComponentB[Props]("ExecutionPlanForm").
-    initialState_P(props => State(new EditableExecutionPlan(props.plan))).
-    renderBackend[Backend].
-    componentDidMount($ => $.backend.mounted($.props)).
-    build
+  val component = ReactComponentB[Props]("ExecutionPlanForm")
+    .initialState(State(EditableExecutionPlan(None)))
+    .renderBackend[Backend]
+    .componentDidMount($ => $.backend.initialize($.props))
+    .build
 
-  def apply(proxy: ModelProxy[PotMap[JobId, JobSpec]], plan: Option[ExecutionPlan], handler: ScheduleHandler) =
-    component(Props(proxy, plan, handler))
+  def apply(proxy: ModelProxy[PotMap[JobId, JobSpec]], handler: Handler, refName: String) =
+    component.withRef(refName)(Props(proxy, handler))
 
 }

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
@@ -84,15 +84,15 @@ object ExecutionPlanForm {
 
     // Event handlers
 
-    def onModalClosed(props: Props, state: State): Callback = {
-      def command: Option[ScheduleJob] = if (!state.cancelled) {
+    def onModalClosed(props: Props): Callback = {
+      def command(state: State): Option[ScheduleJob] = if (!state.cancelled) {
         for {
-          jobId <- state.plan.jobId
+          jobId   <- state.plan.jobId
           trigger <- state.plan.trigger
         } yield ScheduleJob(jobId, trigger, state.timeout)
       } else None
 
-      $.modState(_.copy(visible = false)) >> props.handler(command)
+      $.state.map(command) >>= props.handler
     }
 
     // Not supported yet
@@ -147,7 +147,7 @@ object ExecutionPlanForm {
             Modal.Props(
               header = formHeader,
               footer = formFooter,
-              onClosed = onModalClosed(props, state)
+              onClosed = onModalClosed(props)
             ),
             if (!state.showPreview) {
               <.div(

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
@@ -28,6 +28,7 @@ import io.quckoo.console.registry.JobSelect
 import io.quckoo.protocol.scheduler.ScheduleJob
 
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.extra._
 import japgolly.scalajs.react.vdom.prefix_<^._
 
 import monocle.macros.Lenses

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
@@ -92,7 +92,7 @@ object ExecutionPlanForm {
         } yield ScheduleJob(jobId, trigger, state.timeout)
       } else None
 
-      $.state.map(command) >>= props.handler
+      $.modState(_.copy(visible = false)) >> $.state.map(command) >>= props.handler
     }
 
     // Not supported yet
@@ -105,10 +105,10 @@ object ExecutionPlanForm {
       $.modState(st => st.copy(showPreview = !st.showPreview))
 
     def submitForm(): Callback =
-      $.modState(_.copy(visible = false, cancelled = false))
+      $.modState(_.copy(cancelled = false))
 
     def editPlan(plan: Option[ExecutionPlan]): Callback =
-      $.modState(_.copy(plan = new EditableExecutionPlan(plan), visible = true, readOnly = plan.isDefined))
+      $.setState(State(new EditableExecutionPlan(plan), visible = true, readOnly = plan.isDefined))
 
     // Rendering
 

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanForm.scala
@@ -151,9 +151,9 @@ object ExecutionPlanForm {
             ),
             if (!state.showPreview) {
               <.div(
-                JobSelect(jobSpecs(props), jobIdLens.get(state), $.setStateL(jobIdLens)(_)),
-                TriggerSelect(triggerLens.get(state), $.setStateL(triggerLens)(_)),
-                ExecutionTimeoutInput(timeoutLens.get(state), $.setStateL(timeoutLens)(_))
+                JobSelect(jobSpecs(props), jobIdLens.get(state), $.setStateL(jobIdLens)(_), readOnly = state.readOnly),
+                TriggerSelect(triggerLens.get(state), $.setStateL(triggerLens)(_), readOnly = state.readOnly),
+                ExecutionTimeoutInput(timeoutLens.get(state), $.setStateL(timeoutLens)(_), readOnly = state.readOnly)
                 //ExecutionParameterList(Map.empty, onParamUpdate)
               )
             } else {

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanList.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionPlanList.scala
@@ -16,10 +16,11 @@
 
 package io.quckoo.console.scheduler
 
+import diode.data._
 import diode.react.ModelProxy
 import diode.react.ReactPot._
 
-import io.quckoo.{ExecutionPlan, PlanId}
+import io.quckoo.{ExecutionPlan, JobId, JobSpec, PlanId}
 import io.quckoo.console.components._
 import io.quckoo.console.core.ConsoleCircuit.Implicits.consoleClock
 import io.quckoo.console.core.{LoadExecutionPlans, LoadJobSpecs, UserScope}
@@ -31,12 +32,14 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 import org.threeten.bp.ZonedDateTime
 
 import scalaz._
-import Scalaz._
+import scalaz.syntax.applicative.{^ => _, _}
+import scalaz.syntax.show._
 
 /**
   * Created by alonsodomin on 30/01/2016.
   */
 object ExecutionPlanList {
+  import ScalazReact._
 
   final val Columns = List(
     'Job,
@@ -66,7 +69,7 @@ object ExecutionPlanList {
 
   class Backend($ : BackendScope[Props, State]) {
 
-    def mounted(props: Props): Callback = {
+    private[ExecutionPlanList] def initialize(props: Props): Callback = {
       val model = props.proxy()
 
       def loadJobs: Callback =
@@ -75,43 +78,62 @@ object ExecutionPlanList {
       def loadPlans: Callback =
         Callback.when(model.executionPlans.size == 0)(props.proxy.dispatchCB(LoadExecutionPlans))
 
-      loadJobs >> loadPlans
+      loadJobs *> loadPlans
     }
 
-    def renderItem(
-        model: UserScope)(planId: PlanId, plan: ExecutionPlan, column: Symbol): ReactNode = {
-      def displayDateTime(dateTime: ZonedDateTime): ReactNode =
-        DateTimeDisplay(dateTime)
+    // Actions
 
-      column match {
-        case 'Job =>
-          val jobSpec = model.jobSpecs.get(plan.jobId)
-          jobSpec.render(_.displayName)
+    def cancelPlan(planId: PlanId): Callback =
+      $.props.flatMap(_.proxy.dispatchCB(CancelExecutionPlan(planId)))
 
-        case 'Current   => plan.currentTask.map(_.show).getOrElse(Cord.empty).toString()
-        case 'Trigger   => plan.trigger.toString()
-        case 'Scheduled => plan.lastScheduledTime.map(displayDateTime).orNull
-        case 'Execution => plan.lastExecutionTime.map(displayDateTime).orNull
-        case 'Outcome   => plan.lastOutcome.map(_.toString).getOrElse[String]("")
-        case 'Next      => plan.nextExecutionTime.map(displayDateTime).orNull
+    // Event handlers
+
+    def onFilterClicked(filterType: Symbol): Callback =
+      $.modState(_.copy(selectedFilter = Some(filterType)))
+
+    def onPlanClicked(planId: PlanId): Callback = {
+      def planClickedCB(plan: ExecutionPlan): Callback =
+        $.props.flatMap(_.onClick(plan))
+
+      def planIsNotReady: Callback =
+        Callback.alert(s"Execution plan '$planId' is not ready yet.")
+
+      $.props.map(_.proxy()).flatMap {
+        _.executionPlans.get(planId).headOption.map(planClickedCB).getOrElse(planIsNotReady)
       }
     }
 
-    def cancelPlan(props: Props)(planId: PlanId): Callback =
-      props.proxy.dispatchCB(CancelExecutionPlan(planId))
+    // Rendering
 
-    def rowActions(props: Props)(planId: PlanId, plan: ExecutionPlan) = {
+    def renderItem(model: UserScope)(planId: PlanId, plan: ExecutionPlan, column: Symbol): ReactNode = {
+      def renderPlanName: ReactNode = {
+        val jobSpec = model.jobSpecs.get(plan.jobId)
+        <.a(^.onClick --> onPlanClicked(planId), jobSpec.render(_.displayName))
+      }
+
+      def renderDateTime(dateTime: ZonedDateTime): ReactNode =
+        DateTimeDisplay(dateTime)
+
+      column match {
+        case 'Job       => renderPlanName
+        case 'Current   => plan.currentTask.map(_.show).getOrElse(Cord.empty).toString()
+        case 'Trigger   => plan.trigger.toString()
+        case 'Scheduled => plan.lastScheduledTime.map(renderDateTime).orNull
+        case 'Execution => plan.lastExecutionTime.map(renderDateTime).orNull
+        case 'Outcome   => plan.lastOutcome.map(_.toString).getOrElse[String]("")
+        case 'Next      => plan.nextExecutionTime.map(renderDateTime).orNull
+      }
+    }
+
+    def renderRowActions(props: Props)(planId: PlanId, plan: ExecutionPlan) = {
       if (!plan.finished && plan.nextExecutionTime.isDefined) {
         Seq(
           Table.RowAction[PlanId, ExecutionPlan](
             NonEmptyList(Icons.stop, "Cancel"),
-            cancelPlan(props))
+            cancelPlan)
         )
       } else Seq.empty
     }
-
-    def filterClicked(filterType: Symbol): Callback =
-      $.modState(_.copy(selectedFilter = Some(filterType)))
 
     def render(props: Props, state: State) = {
       val model = props.proxy()
@@ -124,13 +146,13 @@ object ExecutionPlanList {
         ),
         NavBar(
           NavBar
-            .Props(List('All, 'Active, 'Inactive), 'All, filterClicked, style = NavStyle.pills),
+            .Props(List('All, 'Active, 'Inactive), 'All, onFilterClicked, style = NavStyle.pills),
           Table(
             Columns,
             model.executionPlans.seq,
             renderItem(model),
             key = Some("executionPlans"),
-            actions = Some(rowActions(props)(_, _)),
+            actions = Some(renderRowActions(props)(_, _)),
             filter = state.selectedFilter.flatMap(Filters.get))
         )
       )
@@ -141,7 +163,7 @@ object ExecutionPlanList {
   private[this] val component = ReactComponentB[Props]("ExecutionPlanList")
     .initialState(State())
     .renderBackend[Backend]
-    .componentDidMount($ => $.backend.mounted($.props))
+    .componentDidMount($ => $.backend.initialize($.props))
     .build
 
   def apply(proxy: ModelProxy[UserScope], onCreate: OnCreate, onClick: OnClick) =

--- a/console/src/main/scala/io/quckoo/console/scheduler/ExecutionTimeoutInput.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/ExecutionTimeoutInput.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.FiniteDuration
   */
 object ExecutionTimeoutInput {
 
-  case class Props(value: Option[FiniteDuration], onUpdate: Option[FiniteDuration] => Callback)
+  case class Props(value: Option[FiniteDuration], onUpdate: Option[FiniteDuration] => Callback, readOnly: Boolean)
   case class State(enabled: Boolean = false)
 
   class Backend($ : BackendScope[Props, State]) {
@@ -52,14 +52,16 @@ object ExecutionTimeoutInput {
                 <.input.checkbox(
                   ^.id := "enableTimeout",
                   ^.value := state.enabled,
-                  ^.onChange --> onFlagUpdate
+                  ^.onChange --> onFlagUpdate,
+                  ^.readOnly := props.readOnly,
+                  ^.disabled := props.readOnly
                 ),
                 "Enabled"
               )))),
         if (state.enabled) {
           <.div(
             ^.`class` := "col-sm-offset-2",
-            FiniteDurationInput("timeout", props.value, onValueUpdate))
+            FiniteDurationInput("timeout", props.value, onValueUpdate, props.readOnly))
         } else EmptyTag
       )
     }
@@ -71,7 +73,7 @@ object ExecutionTimeoutInput {
     .renderBackend[Backend]
     .build
 
-  def apply(value: Option[FiniteDuration], onUpdate: Option[FiniteDuration] => Callback) =
-    component(Props(value, onUpdate))
+  def apply(value: Option[FiniteDuration], onUpdate: Option[FiniteDuration] => Callback, readOnly: Boolean = false) =
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
@@ -60,7 +60,8 @@ object SchedulerPage {
     }
 
     def editPlan(plan: Option[ExecutionPlan]): Callback = {
-      executionPlanForm.flatMapF(_.editPlan(plan)).getOrElseF(Callback.empty)
+      executionPlanForm.flatMapF(_.editPlan(plan))
+        .getOrElseF(Callback.log("Reference {} points to nothing!", executionPlanFormRef.name))
     }
 
     def render(props: Props) = {

--- a/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
@@ -49,7 +49,7 @@ object SchedulerPage {
 
   class Backend($ : BackendScope[Props, Unit]) {
 
-    def executionPlanForm: OptionT[CallbackTo, ExecutionPlanForm.Backend] =
+    lazy val executionPlanForm: OptionT[CallbackTo, ExecutionPlanForm.Backend] =
       OptionT(CallbackTo.lift(() => executionPlanFormRef($).toOption.map(_.backend)))
 
     def scheduleJob(scheduleJob: Option[ScheduleJob]): Callback = {

--- a/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
@@ -19,9 +19,8 @@ package io.quckoo.console.scheduler
 import diode.react.ModelProxy
 
 import io.quckoo.ExecutionPlan
-import io.quckoo.console.components.{Button, Icons, TabPanel}
+import io.quckoo.console.components._
 import io.quckoo.console.core.ConsoleScope
-import io.quckoo.console.layout.GlobalStyles
 import io.quckoo.protocol.scheduler.ScheduleJob
 
 import japgolly.scalajs.react._
@@ -43,7 +42,7 @@ object SchedulerPage {
 
   final case class Props(proxy: ModelProxy[ConsoleScope])
 
-  private lazy val executionPlanFormRef = Ref.to(ExecutionPlanForm.component, "executionPlanFormRef")
+  private lazy val executionPlanFormRef = Ref.to(ExecutionPlanForm.component, "ExecutionPlanForm")
 
   class Backend($ : BackendScope[Props, Unit]) {
 
@@ -54,9 +53,8 @@ object SchedulerPage {
       $.props >>= dispatchAction
     }
 
-    def editPlan(plan: Option[ExecutionPlan]): Callback = {
-      executionPlanFormRef($).map(_.backend.editPlan(plan))
-        .getOrElse(Callback.empty)
+    def editPlan(plan: Option[ExecutionPlan]): Callback = Callback {
+      executionPlanFormRef($).get.backend.editPlan(plan).runNow()
     }
 
     def render(props: Props) = {
@@ -72,7 +70,8 @@ object SchedulerPage {
         TabPanel(
           'Plans      -> userScopeConnector(ExecutionPlanList(_, editPlan(None), plan => editPlan(Some(plan)))),
           'Executions -> executionConnector(TaskExecutionList(_))
-        ))
+        )
+      )
     }
 
   }

--- a/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/SchedulerPage.scala
@@ -29,10 +29,13 @@ import japgolly.scalajs.react.vdom.prefix_<^._
 import scalacss.Defaults._
 import scalacss.ScalaCssReact._
 
+import scalaz.OptionT
+
 /**
   * Created by alonsodomin on 17/10/2015.
   */
 object SchedulerPage {
+  import ScalazReact._
 
   object Style extends StyleSheet.Inline {
     import dsl._
@@ -46,6 +49,9 @@ object SchedulerPage {
 
   class Backend($ : BackendScope[Props, Unit]) {
 
+    def executionPlanForm: OptionT[CallbackTo, ExecutionPlanForm.Backend] =
+      OptionT(CallbackTo.lift(() => executionPlanFormRef($).toOption.map(_.backend)))
+
     def scheduleJob(scheduleJob: Option[ScheduleJob]): Callback = {
       def dispatchAction(props: Props): Callback =
         scheduleJob.map(props.proxy.dispatchCB[ScheduleJob]).getOrElse(Callback.empty)
@@ -53,8 +59,8 @@ object SchedulerPage {
       $.props >>= dispatchAction
     }
 
-    def editPlan(plan: Option[ExecutionPlan]): Callback = Callback {
-      executionPlanFormRef($).get.backend.editPlan(plan).runNow()
+    def editPlan(plan: Option[ExecutionPlan]): Callback = {
+      executionPlanForm.flatMapF(_.editPlan(plan)).getOrElseF(Callback.empty)
     }
 
     def render(props: Props) = {

--- a/console/src/main/scala/io/quckoo/console/scheduler/TriggerSelect.scala
+++ b/console/src/main/scala/io/quckoo/console/scheduler/TriggerSelect.scala
@@ -30,19 +30,19 @@ object TriggerSelect {
   type Selector    = CoproductSelect.Selector[Trigger]
   type OnUpdate    = CoproductSelect.OnUpdate[Trigger]
 
-  case class Props(value: Option[Trigger], onUpdate: OnUpdate)
+  case class Props(value: Option[Trigger], onUpdate: OnUpdate, readOnly: Boolean = false)
 
   class Backend($: BackendScope[Props, Unit]) {
 
-    def selectComponent: Selector = {
+    def selectComponent(props: Props): Selector = {
       case 'After =>
-        (value, callback) => AfterTriggerInput(value.map(_.asInstanceOf[Trigger.After]), callback)
+        (value, callback) => AfterTriggerInput(value.map(_.asInstanceOf[Trigger.After]), callback, props.readOnly)
       case 'Every =>
-        (value, callback) => EveryTriggerInput(value.map(_.asInstanceOf[Trigger.Every]), callback)
+        (value, callback) => EveryTriggerInput(value.map(_.asInstanceOf[Trigger.Every]), callback, props.readOnly)
       case 'At =>
-        (value, callback) => AtTriggerInput(value.map(_.asInstanceOf[Trigger.At]), callback)
+        (value, callback) => AtTriggerInput(value.map(_.asInstanceOf[Trigger.At]), callback, props.readOnly)
       case 'Cron =>
-        (value, callback) => CronTriggerInput(value.map(_.asInstanceOf[Trigger.Cron]), callback)
+        (value, callback) => CronTriggerInput(value.map(_.asInstanceOf[Trigger.Cron]), callback, props.readOnly)
     }
 
     val selectInput = CoproductSelect[Trigger] {
@@ -54,8 +54,8 @@ object TriggerSelect {
     }
 
     def render(props: Props) = {
-      selectInput(Options, selectComponent, props.value, Options.head, props.onUpdate,
-        ^.id := "triggerType"
+      selectInput(Options, selectComponent(props), props.value, Options.head, props.onUpdate,
+        ^.id := "triggerType", ^.readOnly := props.readOnly, ^.disabled := props.readOnly
       )(<.label(^.`class` := "col-sm-2 control-label", ^.`for` := "triggerType", "Trigger"))
     }
 
@@ -66,7 +66,7 @@ object TriggerSelect {
     .renderBackend[Backend]
     .build
 
-  def apply(value: Option[Trigger], onUpdate: OnUpdate) =
-    component(Props(value, onUpdate))
+  def apply(value: Option[Trigger], onUpdate: OnUpdate, readOnly: Boolean = false) =
+    component(Props(value, onUpdate, readOnly))
 
 }

--- a/console/src/main/scala/io/quckoo/console/security/LoginForm.scala
+++ b/console/src/main/scala/io/quckoo/console/security/LoginForm.scala
@@ -52,8 +52,8 @@ object LoginForm {
       event.preventDefaultCB >> perform
     }
 
-    val usernameInput = Input[String]()
-    val passwordInput = Input[Password]()
+    private[this] val UsernameInput = Input[String]
+    private[this] val PasswordInput = Input[Password]
 
     def render(handler: LoginHandler, state: State) = {
       <.form(
@@ -62,11 +62,11 @@ object LoginForm {
         <.div(
           ^.`class` := "form-group",
           <.label(^.`for` := "username", ^.`class` := "control-label", "Username"),
-          usernameInput(state.username, onUsernameChange _, ^.id := "username")),
+          UsernameInput(state.username, onUsernameChange _, ^.id := "username")),
         <.div(
           ^.`class` := "form-group",
           <.label(^.`for` := "password", ^.`class` := "control-label", "Password"),
-          passwordInput(state.password, onPasswordChange _, ^.id := "password")),
+          PasswordInput(state.password, onPasswordChange _, ^.id := "password")),
         Button(
           Button.Props(
             style = ContextStyle.primary,


### PR DESCRIPTION
This PR adds similar features to the Scheduler page than the ones added to the Registry page:

- Execution Plan details can be displayed in the same form used to create it in the first place (although is going to be in read-only mode)
- Execution plans can also be cancelled in bulk

Among that, there was bug regarding the usage of component refs in ReactJS that has been fixed now (pesky callbacks!)